### PR TITLE
Bugfix: nested gate info

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.4.2] 2022-11-28
+### Fixed
+- Extra info display for nested gates
+
 ## [0.4.1] 2022-11-21
 ### Added
 - Renderer now updates when changes are made to the circuit json dumped to the DOM

--- a/cypress/fixtures/circuits.js
+++ b/cypress/fixtures/circuits.js
@@ -5,6 +5,7 @@ const QIR = require('./circuits/qir.json')
 const ZX = require('./circuits/zx.json')
 const Boxes = require('./circuits/boxes.json')
 const Nested = require('./circuits/nested.json')
+const SimpleNested = require('./circuits/simple-nested.json')
 const Deep = require('./circuits/1000gates.json')
 
 export {
@@ -15,5 +16,6 @@ export {
   ZX,
   Boxes,
   Nested,
+  SimpleNested,
   Deep
 }

--- a/cypress/fixtures/circuits/simple-nested.json
+++ b/cypress/fixtures/circuits/simple-nested.json
@@ -1,0 +1,36 @@
+{
+  "name":"Simple Nested circuit",
+  "phase":"0.0",
+  "qubits":[["q",[0]],["q",[1]],["p",[0]],["q",[2]]],
+  "bits":[["c",[0]],["c",[1]],["c",[2]],["c",[3]]],
+  "commands":[
+    {"op":{"type":"CX"},"args":[["q",[1]],["q",[0]]]},
+    {"op":{"type":"CH"},"args":[["p",[0]],["q",[2]]]},
+    {"op":{"type":"CnRy","params":["0.25898888888"]},"args":[["q",[2]],["q",[0]],["p",[0]]]},
+    {"op":{"type":"H"},"args":[["q",[0]]]},
+    {"op":{"type":"Rxx","params":["0.25"]},"args":[["q",[1]],["q",[2]]]},
+    {"op":{"type":"X"},"args":[["q",[0]]]},
+    {"op":{"type":"Reset"},"args":[["q",[1]]]},
+    {"op":{"type":"SWAP"},"args":[["q",[0]],["q",[2]]]},
+    {"op":{"type":"CSWAP"},"args":[["p",[0]],["q",[2]],["q",[1]]]},
+    {"op":{"type":"CCX"},"args":[["q",[0]],["q",[1]],["q",[2]]]},
+    {"op":{"type":"CVdg"},"args":[["q",[0]],["q",[2]]]},
+    {"op":{"type":"CRz","params":["0.25"]},"args":[["q",[2]],["q",[0]]]},
+    {"op":{"type":"CircBox","box":{"id":"621ee04f-bc1f-4ae3-bbf5-0db8385e9e01","type":"CircBox","circuit":{
+      "name": "Nested Circbox Level 0",
+      "phase":"0.0",
+      "qubits":[["q",[0]],["q",[1]],["q",[2]],["q",[3]]],
+      "bits":[],"commands":[
+        {"op":{"type":"SWAP"},"args":[["q",[1]],["q",[3]]]},
+        {"op":{"type":"Rx","n_qb":1,"params":["cy", "alpha^2 + beta^3"]},"args":[["q",[1]]]},
+        {"op":{"type":"SWAP"},"args":[["q",[3]],["q",[1]]]},
+        {"op":{"type":"CX"},"args":[["q",[2]],["q",[0]]]}
+      ],
+      "implicit_permutation":[[["q",[0]],["q",[0]]],[["q",[1]],["q",[1]]],[["q",[2]],["q",[2]]],[["q",[3]],["q",[3]]]]}}},
+      "args":[["q",[0]],["q",[1]],["p",[0]],["q",[2]]]
+    },
+    {"op":{"type":"Measure"},"args":[["q",[0]],["c",[0]]]},
+    {"op":{"type":"Measure"},"args":[["q",[2]],["c",[1]]]}
+  ],
+  "implicit_permutation":[[["q",[0]],["q",[0]]],[["q",[1]],["q",[1]]]]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pytket-circuit-renderer",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pytket-circuit-renderer",
   "description": "A Vue 3 component for rendering pytket circuits.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": false,
   "author": {
     "name": "Tiffany Duneau",

--- a/src/components/circuitDisplay/circuitDisplay.scss
+++ b/src/components/circuitDisplay/circuitDisplay.scss
@@ -211,7 +211,7 @@
   .gate_bottom {
     height: calc(var(--box-height) + var(--box-margin) + (2 * var(--box-padding)));
     margin-top: 0;
-    padding-top: var(--box-margin);
+    padding-top: calc(var(--box-padding) + var(--box-margin));
     padding-bottom: var(--box-padding);
     border-top: none;
   }
@@ -230,7 +230,7 @@
     height: calc(var(--box-height) + var(--box-margin) + (2 * var(--box-padding)) + 1px);
     margin-bottom: 0;
     padding-top: var(--box-padding);
-    padding-bottom: var(--box-margin);
+    padding-bottom: calc(var(--box-padding) + var(--box-margin));
     border-bottom: none;
   }
 

--- a/src/components/circuitDisplay/circuitDisplay.stories.js
+++ b/src/components/circuitDisplay/circuitDisplay.stories.js
@@ -80,3 +80,8 @@ export const Nested = Template.bind({})
 Nested.args = {
   circuit: circuitFixtures.Nested
 }
+
+export const SimpleNested = Template.bind({})
+SimpleNested.args = {
+  circuit: circuitFixtures.SimpleNested
+}

--- a/src/components/circuitDisplay/circuitDisplay.vue
+++ b/src/components/circuitDisplay/circuitDisplay.vue
@@ -297,6 +297,9 @@ export default {
     background: var(--box-col-overlay);
     box-shadow: 0 0 0 var(--box-border-width) var(--box-col) inset;
 }
+.theme_variables.dark .nested-circuit-container{
+    box-shadow: 0 0 0 1px var(--paper) inset;
+}
 .navigator-content .nested-circuit-container.parent{
   overflow: hidden;
 }

--- a/src/components/circuitDisplay/circuitDisplayContainer.cy.js
+++ b/src/components/circuitDisplay/circuitDisplayContainer.cy.js
@@ -52,12 +52,45 @@ describe('Circuit display container component', () => {
           cy.contains('SetBits(1,1,0,0)').should('be.visible')
           cy.contains('Range[2, ').should('not.be.visible')
         })
+
         it('can toggle display options', () => {
           cy.mount({ name, ...components[useCase]({ circuitPreset: 'Classical' }) })
           cy.contains('tk_SCRATCH_BIT[0]').should('not.exist')
           cy.get('[title="Display Options"').click()
           cy.contains('Collapse classical registers').click()
           cy.contains('tk_SCRATCH_BIT[0]').should('exist')
+        })
+
+        it('Can view nested info modals', () => {
+          cy.mount({ name, ...components[useCase]({ circuitPreset: 'SimpleNested' }) })
+          cy.get('.navigator-controller.nav-x')
+            .trigger('mousedown', { which: 1 })
+            .trigger('mousemove', { clientX: 350, clientY: 0 })
+            .trigger('mouseup', { which: 1 })
+          cy.get('[data-cy=open-tool-tip-CircBox]').should('be.visible').click()
+          cy.get('[data-cy=teleport-to] [data-cy=teleported-CircBox]').within(() => {
+            cy.contains('Rx(cy').should('exist')
+            cy.get('[data-cy=open-tool-tip-Rx]').should('be.visible').click()
+            cy.get('[data-cy=teleported-Rx]').within(() => {
+              cy.contains('Box params')
+            })
+          })
+        })
+        it('Can view nested info modals when displaying circuits recursively', () => {
+          cy.mount({
+            name,
+            ...components[useCase]({
+              circuitPreset: 'SimpleNested', initOptions: true, condensed: true, recursive: true
+            })
+          })
+          cy.get('.navigator-controller.nav-x')
+            .trigger('mousedown', { which: 1 })
+            .trigger('mousemove', { clientX: 350, clientY: 0 })
+            .trigger('mouseup', { which: 1 })
+          cy.get('[data-cy=open-tool-tip-Rx]').should('be.visible').click()
+          cy.get('[data-cy=teleport-to] [data-cy=teleported-Rx]').within(() => {
+            cy.contains('Box params').should('be.visible')
+          })
         })
         // it('can export the circuit as an image')
       })

--- a/src/components/circuitDisplay/circuitDisplayContainer.vue
+++ b/src/components/circuitDisplay/circuitDisplayContainer.vue
@@ -16,8 +16,8 @@ export default {
     navigatorPreview
   },
   props: {
-    circuitRaw: { type: Object, default: undefined },
-    circuitElementStr: { type: String, default: undefined },
+    circuitRaw: { type: Object, required: false, default: undefined },
+    circuitElementStr: { type: String, required: false, default: undefined },
     initRenderOptions: { type: Object, default: () => { return {} } }
   },
   data () {
@@ -41,7 +41,7 @@ export default {
         condensed: 'condensed' in this.initRenderOptions ? this.initRenderOptions.condensed : true,
         darkTheme: 'darkTheme' in this.initRenderOptions ? this.initRenderOptions.darkTheme : false
       },
-      circuitEl: undefined,
+      circuitEl: null,
       circuitDimensions: {
         width: undefined,
         height: undefined

--- a/src/components/circuitDisplay/gateInfo.vue
+++ b/src/components/circuitDisplay/gateInfo.vue
@@ -8,7 +8,7 @@ import { CONTROLLED_OPS } from './consts'
 import infoModal from './infoModal'
 import gateInfoSubCircuit from './gateInfoSubCircuit'
 import gateInfoClassical from './gateInfoClassical'
-import { renderOptions } from './provideKeys'
+import { renderOptions, teleportConfig } from './provideKeys'
 
 export default {
   name: 'gate-info',
@@ -22,12 +22,11 @@ export default {
     gateInfoClassical
   },
   props: {
-    op: { type: Object, required: true },
-    teleportId: { type: String, required: true },
-    teleportParent: { required: true } // ref to the parent. Undefined until parent is mounted.
+    op: { type: Object, required: true }
   },
   inject: {
-    recursive: { from: renderOptions.recursive }
+    recursive: { from: renderOptions.recursive },
+    teleportId: { from: teleportConfig.to }
   },
   emits: ['register-teleport', 'updated'],
   data () {
@@ -44,7 +43,8 @@ export default {
         'MultiBit', 'RangePredicate',
         'UnitaryTableauBox', 'WASM'
       ],
-      visible: false
+      visible: false,
+      teleportToId: this.teleportId
     }
   },
   computed: {
@@ -142,16 +142,12 @@ export default {
 
 <template>
   <div v-if="hasContent || hasNestedContent">
-    <div @click="visible = true" class="tool-tip-container"></div>
+    <div @click="visible = true" class="tool-tip-container" :data-cy="'open-tool-tip-' + this.opType"></div>
 
     <!-- content to be rendered in the info modal -->
     <div style="display: none">
-      <teleport-from
-          :to="visible ? teleportId : ''"
-          :parent="teleportParent"
-          @register-teleport="(...args) => $emit('register-teleport', ...args)"
-      >
-        <info-modal ref="infoModal" v-model="visible" class="tool-tip-content">
+      <teleport-from :to="visible ? teleportToId : ''">
+        <info-modal ref="infoModal" v-model="visible" class="tool-tip-content" :data-cy="'teleported-'+this.opType">
           <template #title>
             [[# opType #]]
           </template>

--- a/src/components/circuitDisplay/nestedLabelLayer.vue
+++ b/src/components/circuitDisplay/nestedLabelLayer.vue
@@ -34,7 +34,7 @@ export default {
     flex-shrink: 0;
 }
 .nested-label-layer:deep() .wire-label{
-    padding: var(--box-margin) 0;
+    padding: calc(var(--box-margin) + var(--box-padding)) 0;
     height: var(--block-height);
     margin: auto;
 }

--- a/src/components/circuitDisplay/provideKeys.js
+++ b/src/components/circuitDisplay/provideKeys.js
@@ -7,3 +7,8 @@ export const renderOptions = {
   recursive: Symbol('Render option: display nested circuits recursively.'),
   nested: Symbol('Render option: circuit is nested.')
 }
+
+export const teleportConfig = {
+  parent: Symbol('Root teleport container ref'),
+  to: Symbol('Teleport-to id to send modals to')
+}

--- a/src/components/circuitDisplay/splitCircuitLayers.vue
+++ b/src/components/circuitDisplay/splitCircuitLayers.vue
@@ -1,5 +1,6 @@
 <script>
 import { h } from 'vue'
+import { RefValidator } from '@/components/propValidators'
 import CircuitLayer from './circuitLayer'
 import RenderCircuitLayers from './renderCircuitLayers'
 import { SPLIT_RENDERING } from './consts'
@@ -11,8 +12,14 @@ export default {
   components: { RenderCircuitLayers, CircuitLayer },
   props: {
     registerOrder: { type: Array, required: true },
-    commandRefs: { type: Array, required: true },
-    idCommandRef: { type: Object, required: true },
+    commandRefs: {
+      type: Array,
+      validator: (data) => {
+        return data.reduce((acc, ref) => acc && RefValidator(ref), true)
+      },
+      required: true
+    },
+    idCommandRef: { type: Object, validator: RefValidator, required: true },
     condensedRegisters: { type: Object, required: true }
   },
   emits: ['updated'],

--- a/src/components/exportImage/exportImage.vue
+++ b/src/components/exportImage/exportImage.vue
@@ -1,12 +1,13 @@
 <script>
 import domToImage from 'dom-to-image'
+import { RefValidator } from '@/components/propValidators'
 
 export default {
   name: 'export-image',
   emits: ['updated'],
   props: {
     defaultFileName: { type: String, required: false },
-    elementToRender: { type: Object, required: true },
+    elementToRender: { validator: RefValidator, required: true },
     baseDimensions: { type: Object, default: () => { return { width: false, height: false } } }
 
   },

--- a/src/components/navigator/navigatorPreview.vue
+++ b/src/components/navigator/navigatorPreview.vue
@@ -1,14 +1,15 @@
 <script>
 import { navigator } from './provideKeys'
+import { RefValidator } from '@/components/propValidators'
 
 export default {
   name: 'navigator-preview',
   components: {
   },
   props: {
-    direction: { type: String, required: true }, // 'x' | 'y'
+    direction: { type: String, required: true, validator: (val) => val === 'x' || val === 'y' },
     fitZoom: { type: Boolean, default: false },
-    controller: { type: Object, required: true } // Ref to navigator controller
+    controller: { validator: RefValidator, required: true } // Ref to navigator controller
   },
   inject: {
     styles: { from: navigator.styles }

--- a/src/components/propValidators.js
+++ b/src/components/propValidators.js
@@ -1,0 +1,11 @@
+// Validators for required props that can also be null or undefined
+
+const PendingDataValidator = (dataType) => {
+  return (prop) => typeof prop === 'undefined' || prop instanceof dataType
+}
+const RefValidator = (prop) => prop === null || typeof prop === 'undefined' || prop instanceof Object // vue treats refs as objects
+
+export {
+  PendingDataValidator,
+  RefValidator
+}

--- a/src/components/teleport/teleportFrom.vue
+++ b/src/components/teleport/teleportFrom.vue
@@ -1,11 +1,15 @@
 <script>
+import { teleportConfig } from '@/components/circuitDisplay/provideKeys'
+
 let nTeleports = 0 // teleport-from needs a unique id.
 
 export default {
   name: 'teleport-from',
+  inject: {
+    parent: { from: teleportConfig.parent }
+  },
   props: {
     to: { type: String, required: true },
-    parent: { required: true }, // Ref to teleport-container. Undefined until parent is mounted.
     disabled: { type: Boolean, default: false }
   },
   emits: ['register-teleport'],
@@ -34,6 +38,7 @@ export default {
           this.parent.registerTeleport(false, prev, this)
         }
       } else {
+        console.error('must register teleport via events')
         // Fallback: propagate change via events instead.
         // Ensure these are handled if teleport containers can become nested.
         if (next) {


### PR DESCRIPTION
previously nested the gate info modal for nested gates displayed centered relative to the whole circuit (so for long circuits was not visible). Now they are upgraded to display in the same place as the non nested gates.

also contains some minor css improvements for the gate name alignments.