### PR TITLE
Bugfix/phase gate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,9 +12,14 @@ This is to allow user-facing information to be more easily extracted from this c
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Changed:
+### Added:
 - Added render option for transparent background.
+
+### Changed:
 - Theme updated to match quantinuum-ui 2.0
+
+### Fixed:
+- Gates with no args now display in the circuit.
 
 ## [0.4.2] 2022-11-28
 ### Fixed

--- a/cypress/fixtures/circuits.js
+++ b/cypress/fixtures/circuits.js
@@ -7,6 +7,7 @@ const Boxes = require('./circuits/boxes.json')
 const Nested = require('./circuits/nested.json')
 const SimpleNested = require('./circuits/simple-nested.json')
 const Deep = require('./circuits/1000gates.json')
+const Phase = require('./circuits/phase.json')
 
 export {
   Basic,
@@ -17,5 +18,6 @@ export {
   Boxes,
   Nested,
   SimpleNested,
-  Deep
+  Deep,
+  Phase
 }

--- a/cypress/fixtures/circuits/phase.json
+++ b/cypress/fixtures/circuits/phase.json
@@ -1,0 +1,39 @@
+{
+  "phase":"0.5",
+  "commands":[
+    {"op":{"type":"U3","params":["1.0","-0.5","0.5"]},"args":[["q",[0]]]},
+    {"op":{"type":"Measure"},"args":[["q",[1]],["c",[1]]]},
+    {
+      "op": {
+        "conditional": {
+          "op": {"type": "Phase",  "params": ["0.1"]}, "value": 1, "width": 1
+        },
+        "type": "Conditional"
+      },
+      "args": [["c", [0]]]
+    },
+    {"op": {"type": "Phase", "params": ["0.25"]}, "args": null},
+    {"op": {"type": "Fake Gate", "params": ["0.25"]}, "args": null},
+    {"op":{"type":"CircBox","box":{"id":"621ee04f-bc1f-4ae3-bbf5-0db8385e9e01","type":"CircBox","circuit":{
+      "name": "Circbox with Phase Gate",
+      "phase":"0.0",
+      "qubits":[["q",[0]],["q",[1]]],
+      "bits":[],
+      "commands":[
+        {"op":{"type":"SWAP"},"args":[["q",[1]],["q",[0]]]},
+        {"op":{"type":"Rx","n_qb":1,"params":["cy", "alpha^2 + beta^3"]},"args":[["q",[1]]]},
+        {"op": {"type": "Phase", "params": ["0.5"]}, "args": null},
+        {"op": {"type": "Phase", "params": ["0.5"]}, "args": null},
+        {"op":{"type":"CZ"},"args":[["q",[0]],["q",[1]]]},
+        {"op":{"type":"CX"},"args":[["q",[1]],["q",[0]]]}
+      ],
+      "implicit_permutation":[[["q",[0]],["q",[0]]],[["q",[1]],["q",[1]]],[["q",[2]],["q",[2]]],[["q",[3]],["q",[3]]]]}}},
+      "args":[["q",[0]],["q",[1]]]
+    },
+    {"op":{"type":"Measure"},"args":[["q",[0]],["c",[0]]]},
+    {"op":{"type":"Measure"},"args":[["q",[1]],["c",[1]]]}
+  ],
+  "qubits":[["q",[0]],["q",[1]]],
+  "bits":[["c",[0]],["c",[1]]],
+  "implicit_permutation":[[["q",[0]],["q",[0]]],[["q",[1]],["q",[1]]]]
+}

--- a/src/components/circuitDisplay/circuitDisplay.scss
+++ b/src/components/circuitDisplay/circuitDisplay.scss
@@ -143,7 +143,7 @@
   }
 
   .wire.transparent-wire {
-    background: transparent;
+    background: transparent !important;
   }
 
   /* Generic base for our gates */
@@ -188,6 +188,11 @@
   .gate.gate_special {
     --box-margin: calc((var(--block-height) - var(--box-height)) / 2);
     --box-padding: 0em;
+  }
+
+  .gate.gate_0q {
+    border-color: transparent;
+    background: var(--paper-dark);
   }
 
   .gate.connected {

--- a/src/components/circuitDisplay/circuitDisplay.stories.js
+++ b/src/components/circuitDisplay/circuitDisplay.stories.js
@@ -85,3 +85,8 @@ export const SimpleNested = Template.bind({})
 SimpleNested.args = {
   circuit: circuitFixtures.SimpleNested
 }
+
+export const Phase = Template.bind({})
+Phase.args = {
+  circuit: circuitFixtures.Phase
+}

--- a/src/components/circuitDisplay/command.vue
+++ b/src/components/circuitDisplay/command.vue
@@ -29,22 +29,37 @@ export default {
     },
     commandArgs () {
       const [firstArg, lastArg, argDetails] = [{}, {}, {}]
-      this.command.args.forEach((arg, pos) => {
-        const order = this.registerOrder.findIndex(reg => registerEquality(reg, arg))
-        if (!('order' in firstArg) || order < firstArg.order) {
-          firstArg.order = order
-          firstArg.name = arg
-        }
-        if (!('order' in lastArg) || order > lastArg.order) {
-          lastArg.order = order
-          lastArg.name = arg
-        }
-        argDetails[arg] = {
-          name: arg,
-          pos, // index of arg in the command
-          order // index of arg in the display order
-        }
-      })
+      if (!this.command.args || this.command.args.length === 0) {
+        // There are no args for this command. Render it in the correct layer, but passing through all wires.
+        firstArg.order = 0
+        firstArg.name = this.registerOrder[0]
+        lastArg.order = this.registerOrder.length - 1
+        lastArg.name = this.registerOrder[this.registerOrder.length - 1]
+        this.registerOrder.forEach((arg, order) => {
+          argDetails[arg] = {
+            name: arg,
+            pos: order,
+            order
+          }
+        })
+      } else {
+        this.command.args.forEach((arg, pos) => {
+          const order = this.registerOrder.findIndex(reg => registerEquality(reg, arg))
+          if (!('order' in firstArg) || order < firstArg.order) {
+            firstArg.order = order
+            firstArg.name = arg
+          }
+          if (!('order' in lastArg) || order > lastArg.order) {
+            lastArg.order = order
+            lastArg.name = arg
+          }
+          argDetails[arg] = {
+            name: arg,
+            pos, // index of arg in the command
+            order // index of arg in the display order
+          }
+        })
+      }
       return {
         details: argDetails,
         first: firstArg ? argDetails[firstArg.name] : undefined,
@@ -120,7 +135,7 @@ export default {
           flags: {
             first: order === this.commandArgs.first.order,
             last: order === this.commandArgs.last.order,
-            single: this.command.args.length === 1,
+            single: this.command.args && this.command.args.length === 1,
             classical,
             condensed: false,
             globalClassical: false

--- a/src/components/circuitDisplay/gateComponent.vue
+++ b/src/components/circuitDisplay/gateComponent.vue
@@ -35,10 +35,10 @@ export default {
         gate_box: this.command.args.length === 1 || this.arg.flags.single || this.split,
         classical: this.arg.flags.classical,
         condensed: this.arg.flags.condensed,
-        connected: this.arg.pos !== -1,
         gate_reset: this.opType === 'Reset',
         gate_barrier: this.opType === 'Barrier',
         gate_special: this.zxStyle && (this.opType === 'H' || this.isSpider || this.opType === 'Reset'),
+        gate_0q: this.opType === 'Phase',
         'zx-hadamard': this.opType === 'H' && this.zxStyle,
         'zx-spider': this.zxStyle && this.isSpider
       }
@@ -171,9 +171,10 @@ export default {
     <!-- Generic single block gate -->
     <div v-else class="gate_container nested" style="height:var(--block-height)">
       <wire v-if="arg.pos !== -1" class="wire_in" :class="{flex_wire: arg.flags.single}" :classical="arg.flags.classical" :condensed="arg.flags.condensed"></wire>
+      <wire v-else class="wire_in transparent-wire" :class="{flex_wire: arg.flags.single}" :classical="arg.flags.classical" :condensed="arg.flags.condensed"></wire>
 
       <div class="gate_container" :class="[gateColor, {'generic': !arg.flags.single}]">
-        <div class="gate" :class="specialGateClasses">
+        <div class="gate connected" :class="specialGateClasses">
           <span v-if="arg.pos !== -1 && !arg.flags.single" class="wire-label">
             [[# posStr #]]
           </span>
@@ -185,6 +186,7 @@ export default {
       </div>
 
       <wire v-if="arg.pos !== -1" class="wire_in" :class="{flex_wire: arg.flags.single}" :classical="arg.flags.classical" :condensed="arg.flags.condensed"></wire>
+      <wire v-else class="wire_in transparent-wire" :class="{flex_wire: arg.flags.single}" :classical="arg.flags.classical" :condensed="arg.flags.condensed"></wire>
     </div>
 
   </div>

--- a/src/components/circuitDisplay/genericGate.vue
+++ b/src/components/circuitDisplay/genericGate.vue
@@ -51,6 +51,24 @@ export default {
       // Note: we will only have a controlled operation here if we need to render it specially.
       return ['SWAP', 'Measure', 'CX', 'CZ'].includes(this.opType)
     },
+    special0qGate () {
+      // Construct a fake arg for display purposes if this gate doesn't have any.
+      const flag = !(this.opType === 'ID' || (this.command.args && this.command.args.length > 0))
+      if (flag) {
+        const fakeArg = this.indexedArgs[0]
+        fakeArg.flags.first = true
+        fakeArg.flags.last = true
+        fakeArg.flags.single = true
+        fakeArg.pos = -1
+        return {
+          flag: flag,
+          fakeCommandArgs: [this.indexedArgs[0].name],
+          fakeIndexedArg: fakeArg,
+          name: this.$refs.special0qGateComponent ? this.$refs.special0qGateComponent.name : this.opType
+        }
+      }
+      return { flag }
+    },
     nestedCircuitGate () {
       return this.recursive && this.nestedCircuit
     },
@@ -75,7 +93,7 @@ export default {
       </div>
     </div>
 
-    <!-- Special -->
+    <!-- Special: 2Q Gate -->
     <div v-if="special2qGate" data-gate="Special">
       <div v-for="(arg, i) in renderIndexedArgs" :key="i"
           class="gate_container nested" style="height:var(--block-height)"
@@ -115,7 +133,21 @@ export default {
       </div>
     </div>
 
-    <!-- Nested -->
+    <!-- Special: No args -->
+    <div v-if="special0qGate.flag" data-gate="Special:no-args">
+      <div v-for="(arg, i) in renderIndexedArgs" :key="i" class="gate_container">
+        <gate-component v-if="i === 0" ref="special0qGateComponent"
+            :arg="special0qGate.fakeIndexedArg"
+            :pos-adjust="posAdjust"
+            :split="split"
+            :command="{ op: command.op, args: special0qGate.fakeCommandArgs }"
+            :link-vertical="linkVertical">
+        </gate-component>
+        <wire v-else :classical="arg.flags.classical" :condensed="arg.flags.condensed"></wire>
+      </div>
+    </div>
+
+    <!-- Special: Nested -->
     <div v-if="nestedCircuitGate" class="gate_container nested">
       <circuit-layer :nested="true">
         <div v-for="(arg, i) in renderIndexedArgs" :key="i" class="gate_container">
@@ -137,7 +169,7 @@ export default {
     </div>
 
     <!-- Generic -->
-    <div v-if="opType !== 'ID' && !special2qGate && !nestedCircuitGate">
+    <div v-if="opType !== 'ID' && !special2qGate && !special0qGate.flag && !nestedCircuitGate">
       <gate-component v-for="(arg, i) in renderIndexedArgs" :key="i"
               :arg="arg"
               :pos-adjust="posAdjust"

--- a/src/components/circuitDisplay/utils.js
+++ b/src/components/circuitDisplay/utils.js
@@ -173,6 +173,7 @@ const extractControlledCommand = function (controlCommand, argDetails) {
     cc: { ...controlCommand },
     details: argDetails ? { ...argDetails } : false
   }
+  // Keep converting while the nested command is a control op.
   while (CONTROLLED_OPS.includes(converting.cc.op.type)) {
     converting = convert(converting.cc, converting.details)
   }
@@ -183,6 +184,11 @@ const extractControlledCommand = function (controlCommand, argDetails) {
       if (arg in converting.details) converting.details[arg].controlled = true
       else converting.details[arg] = { controlled: true }
     })
+    // Can get controlled 0-q gates (eg Phase) which need special handling:
+    if (!converting.cc.args || converting.cc.args.length === 0) {
+      // Assign the phase to the first register involved.
+      converting.details[controlCommand.args[0]].controlled = true
+    }
   }
 
   return { command: converting.cc, argDetails: converting.details }


### PR DESCRIPTION
Fix renderer to allow gates with no args (eg Phase gates).
Display such gates on the first qubit, but disconnected from the wire.
Phase gates can also be controlled:
<img width="535" alt="Screenshot 2023-01-30 at 14 29 36" src="https://user-images.githubusercontent.com/37022011/215504968-ceaa5b1f-72b0-4da3-9191-1a1308d5c9c8.png">
<img width="526" alt="Screenshot 2023-01-30 at 14 29 27" src="https://user-images.githubusercontent.com/37022011/215504975-3480df8f-d0ac-4c9e-8227-1eabfe12a55f.png">

