### PR TITLE
v0.6.0, add note to image export

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ This is to allow user-facing information to be more easily extracted from this c
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.6.0] 2023-10-30
 ### Changed:
 - Controlled gates now display as large blocks, and recursive display is enabled for controlled sub-circuits.
 - Updated UI icons to make their functionality clearer.
@@ -20,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added:
 - Transparent background toggle to render options.
 - Truncate long params render option (enabled by default). When disabled, long parameters are displayed in full.
+- Note about SVG image export.
 
 ## [0.5.0] 2023-10-30
 ### Added:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pytket-circuit-renderer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pytket-circuit-renderer",
   "description": "A Vue 3 component for rendering pytket circuits.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "author": {
     "name": "Tiffany Duneau",

--- a/src/components/exportImage/exportImage.vue
+++ b/src/components/exportImage/exportImage.vue
@@ -116,6 +116,9 @@ export default {
 
 <template>
     <div class="download-image-container" :class="{rendering: rendering}">
+      <p>Note: when exporting as an SVG, the image is intended for browser display only, and is not displayed by image editors.</p>
+      <p>To get a high quality image for inclusion in slides, you can use a PNG format at higher resolution.</p>
+      <div class="divider"></div>
       <form>
         <div class="flex" v-for="(option, name) in options" :key="name">
           <span class="tab-option-label">[[# option.title #]]</span>

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -75,6 +75,13 @@
     cursor: default;
   }
 
+  .divider {
+    border-bottom: 1px solid var(--divider);
+    height: 0;
+    width: 100%;
+    margin: 20px 0;
+  }
+
   .row {
     color: var(--text-secondary);
     display: flex;


### PR DESCRIPTION
New version release.
Also add a note about the image exports:
<img width="485" alt="Screenshot 2023-03-08 at 15 34 34" src="https://user-images.githubusercontent.com/37022011/223757263-21bf4408-94f6-4402-85c6-6401f5324b4e.png">
