### PR TITLE
misc bugfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed:
 - Refactor mathjs to reduce component size.
 
+### Fixed
+- Allow scrolling on the render options menu.
+
 ## [0.6.0] 2023-03-08
 ### Changed:
 - Controlled gates now display as large blocks, and recursive display is enabled for controlled sub-circuits.

--- a/src/components/circuitDisplay/circuitDisplayContainer.vue
+++ b/src/components/circuitDisplay/circuitDisplayContainer.vue
@@ -335,13 +335,15 @@ export default {
 .display-options-menu {
   position: absolute;
   top: 3em;
+  bottom: 0;
+  max-height: calc(100% - 5em);
   left: 0;
   margin: 0.6em;
   background: var(--background);
   border-radius: 0.4em;
   box-shadow: 0px 5px 10px 0px rgba($grey900, 0.1);
   border: 1px solid var(--paper);
-  overflow: hidden;
+  overflow: auto;
   z-index: 1;
 }
 .display-options-menu-entry {


### PR DESCRIPTION
I somehow managed to accidentally push straight to main (which should hopefully no longer be possible)

The already merged changes were making the mathjs usage more modular to reduce the webpack bundle size.

This fix is for the render options display, which now scrolls if there are too many to fit directly)