### PR TITLE
Feature/update default options fix scroll

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ This is to allow user-facing information to be more easily extracted from this c
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed:
+- Scrolling events passed on to parent when the circuit container is fully scrolled.
 
 ## [0.6.3] 2023-06-05
 ### Added:

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ This is to allow user-facing information to be more easily extracted from this c
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed:
+- Default render options now disable zx-styles and enable the system theme.
 ### Fixed:
 - Scrolling events passed on to parent when the circuit container is fully scrolled.
 

--- a/src/components/circuitDisplay/circuitDisplayContainer.vue
+++ b/src/components/circuitDisplay/circuitDisplayContainer.vue
@@ -35,12 +35,12 @@ export default {
       scrollY: 0,
       width: 0,
       renderOptions: {
-        zxStyle: 'zxStyle' in this.initRenderOptions ? this.initRenderOptions.zxStyle : true,
+        zxStyle: 'zxStyle' in this.initRenderOptions ? this.initRenderOptions.zxStyle : false,
         condenseCBits: 'condenseCBits' in this.initRenderOptions ? this.initRenderOptions.condenseCBits : true,
         recursive: 'recursive' in this.initRenderOptions ? this.initRenderOptions.recursive : false,
         wrap: 'condensed' in this.initRenderOptions ? !this.initRenderOptions.condensed : false,
         darkTheme: 'darkTheme' in this.initRenderOptions ? this.initRenderOptions.darkTheme : false,
-        systemTheme: 'systemTheme' in this.initRenderOptions ? this.initRenderOptions.systemTheme : false,
+        systemTheme: 'systemTheme' in this.initRenderOptions ? this.initRenderOptions.systemTheme : true,
         transparentBg: 'transparentBg' in this.initRenderOptions ? this.initRenderOptions.transparentBg : false,
         cropParams: 'cropParams' in this.initRenderOptions ? this.initRenderOptions.cropParams : true
       },

--- a/src/components/navigator/navigator.vue
+++ b/src/components/navigator/navigator.vue
@@ -253,17 +253,26 @@ export default {
       this.scrolling[this.scrolling.direction] = mouseOffsets[this.scrolling.direction]
     },
     wheelScroll (e) {
-      this.intervalScroll(e.deltaX * 0.001, e.deltaY * 0.001)
+      const noChange = this.intervalScroll(e.deltaX * 0.001, e.deltaY * 0.001)
+      if (!noChange) {
+        e.stopPropagation()
+        e.preventDefault()
+      }
     },
     intervalScroll (xDiff, yDiff) {
-      this.offsetX = this.adjustOffset(
+      const offsetX = this.adjustOffset(
         Math.max(0, Math.min(this.offsetX + xDiff, 1)),
         'x'
       )
-      this.offsetY = this.adjustOffset(
+      const offsetY = this.adjustOffset(
         Math.max(0, Math.min(this.offsetY + yDiff, 1)),
         'y'
       )
+      if (this.offsetX === offsetX && this.offsetY === offsetY) {
+        return true
+      }
+      this.offsetX = offsetX
+      this.offsetY = offsetY
     },
     jumpScroll (direction, e) {
       // Jump the scrollbar to the clicked point.
@@ -324,7 +333,7 @@ export default {
 
     <div class="navigator-content" ref="contentSize"
          @wheel.ctrl.prevent.stop="wheelZoom"
-         @wheel.exact.prevent.stop="wheelScroll"
+         @wheel.exact="wheelScroll"
     >
       <div ref="content" class="no-text-highlighting" :style="styles.content">
         <slot name="content">


### PR DESCRIPTION
### Changed:
- Default render options now disable zx-styles and enable the system theme.
### Fixed:
- Scrolling events passed on to parent when the circuit container is fully scrolled, so you can continue scrolling the page when hovered over the renderer.
