### PR TITLE
gateInfo support for Pauli Pair/CommutingSet boxes.

### DIFF
--- a/cypress/fixtures/circuits/boxes.json
+++ b/cypress/fixtures/circuits/boxes.json
@@ -120,8 +120,19 @@
       "matrix":[[[0,0],[1,0]],[[0.707,0.707],[0,-1]]]}},"args":[["q",[2]],["c",[0]]]},
     {"op":{"type":"StabiliserAssertionBox","box":{"id":"80607fe8-8718-43e7-ac7f-63c772441c1d","type":"StabiliserAssertionBox",
       "stabilisers":[{"coeff":true,"string":["X"]},{"coeff":true,"string":["Y"]},{"coeff":false,"string":["Z"]}]}},"args":[["q",[0]],["q",[2]],["c",[0]],["c",[1]],["c",[2]]]},
-    {"op":{"type":"PauliExpBox","box":{"id":"205eff17-1b1c-4cbe-97bd-6150b131a833","type":"PauliExpBox",
-      "paulis":["X","Z"],"phase":"0.634"}},"args":[["q",[2]],["q",[1]]]},
+    {"args": [["q", [0]], ["q", [1]]], "op": {"box": {
+      "cx_config": "Snake", "id": "dc34b85b-1bd9-4b36-9e13-bb5e47ab095e",
+      "paulis": ["X", "Y"], "phase": "0.5", "type": "PauliExpBox"}, "type": "PauliExpBox"}},
+    {"args": [["q", [3]], ["q", [2]]], "op": {"box": {
+      "cx_config": "MultiQGate", "id": "e4269811-9938-458e-aa7e-bc5183e8ebba",
+      "paulis_pair": [["X", "Y"], ["Z", "Z"]], "phase_pair": ["0.5", "0.2"], "type": "PauliExpPairBox"}, "type": "PauliExpPairBox"}},
+    {"args": [["q", [0]], ["q", [3]]], "op": {"box": {
+      "cx_config": "Star", "id": "c588b00c-bb44-4f64-b9f9-b386c9fec942",
+      "pauli_gadgets": [[["X", "X"], "0.1"], [["Y", "Y"], "0.2"], [["Z", "Z"], "0.3"]], "type": "PauliExpCommutingSetBox"}, "type": "PauliExpCommutingSetBox"}},
+    {"args": [["q", [3]]], "op": {"box": {"cx_config": "MultiQGate", "id": "16026a98-474e-4175-a35f-2b39172e704b",
+      "paulis_pair": [["Z"], ["X"]], "phase_pair": ["0.5", "0.2"], "type": "PauliExpPairBox"}, "type": "PauliExpPairBox"}},
+    {"args": [["q", [3]], ["q", [2]], ["q", [1]]], "op": {"box": {"cx_config": "MultiQGate", "id": "b0684046-551c-4647-a9f7-c8b11d03fe65",
+      "paulis_pair": [["Z", "X", "X"], ["X", "Z", "X"]], "phase_pair": ["0.5", "0.2"], "type": "PauliExpPairBox"}, "type": "PauliExpPairBox"}},
     {"op":{"type":"PhasePolyBox","box":{"id":"671434a7-e7f4-48de-b687-b660f687545f","type":"PhasePolyBox",
       "n_qubits":2,"qubit_indices":[[["q",[2]],1],[["q",[1]],2]],
       "phase_polynomial":[[[false,false],0.4],[[false,true],0.3],[[true,false],0.2],[[true,true],0.1]],

--- a/src/components/circuitDisplay/consts.js
+++ b/src/components/circuitDisplay/consts.js
@@ -1,7 +1,7 @@
 const CONTROLLED_OPS = [
-  'CX', 'CY', 'CZ', 'CH',
+  'CX', 'CY', 'CZ', 'CH', 'CS', 'CSdg',
   'CRx', 'CRy', 'CRz', 'CU1', 'CU3',
-  'CV', 'CVdg', 'CSx', 'CSXdg', 'CSWAP',
+  'CV', 'CVdg', 'CSX', 'CSXdg', 'CSWAP',
   'CnRy', 'CnX', 'CnY', 'CnZ', 'CCX',
   'Control', 'QControlBox',
   'Condition', 'Conditional',

--- a/src/components/circuitDisplay/gateInfo.vue
+++ b/src/components/circuitDisplay/gateInfo.vue
@@ -37,6 +37,7 @@ export default {
       contentOps: [
         'Unitary1qBox', 'Unitary2qBox', 'Unitary3qBox',
         'ExpBox', 'PauliExpBox', 'ClassicalExpBox',
+        'PauliExpPairBox', 'PauliExpCommutingSetBox',
         'PhasePolyBox', 'CircBox', 'Conditional',
         'Custom', 'CustomGate', 'Composite', 'CompositeGate',
         'ProjectorAssertionBox', 'StabiliserAssertionBox',
@@ -161,11 +162,47 @@ export default {
             </chart-def>
 
             <div v-if="displayOp.type === 'PauliExpBox'">
-              <chart-def title="Phase" hover>
+              <chart-def title="Paulis">
+                Phase
+              </chart-def>
+              <chart-def hover>
+                <template #title>
+                  <chart-list :chart="displayOp.box.paulis"></chart-list>
+                </template>
                 <mathjax-content :formula="'\`' + displayOp.box.phase + '\`'"></mathjax-content>
               </chart-def>
-              <chart-def title="Paulis" hover>
-                <chart-list :chart="displayOp.box.paulis"></chart-list>
+              <chart-def v-if="displayOp.box.cx_config" title="Config" hover>
+                [[# displayOp.box.cx_config #]]
+              </chart-def>
+            </div>
+
+            <div v-if="displayOp.type === 'PauliExpPairBox'">
+              <chart-def title="Paulis">
+                Phase
+              </chart-def>
+              <chart-def v-for="(paulis, i) in displayOp.box.paulis_pair" :key="i" hover>
+                <template #title>
+                  <chart-list :chart="paulis"></chart-list>
+                </template>
+                <mathjax-content :formula="'\`' + displayOp.box.phase_pair[i] + '\`'"></mathjax-content>
+              </chart-def>
+              <chart-def v-if="displayOp.box.cx_config" title="Config" hover>
+                [[# displayOp.box.cx_config #]]
+              </chart-def>
+            </div>
+
+            <div v-if="displayOp.type === 'PauliExpCommutingSetBox'">
+              <chart-def title="Pauli Gadgets">
+                Phase
+              </chart-def>
+              <chart-def v-for="(gadget, i) in displayOp.box.pauli_gadgets" :key="i" hover>
+                <template #title>
+                  <chart-list :chart="gadget[0]"></chart-list>
+                </template>
+                <mathjax-content :formula="'\`' + gadget[1] + '\`'"></mathjax-content>
+              </chart-def>
+              <chart-def v-if="displayOp.box.cx_config" title="Config" hover>
+                [[# displayOp.box.cx_config #]]
               </chart-def>
             </div>
 

--- a/src/components/circuitDisplay/utils.js
+++ b/src/components/circuitDisplay/utils.js
@@ -117,7 +117,7 @@ const extractControlledCommand = function (controlCommand, argDetails) {
     // Overload for when we only care about the op, and set args to false.
     if (['CX', 'CY', 'CZ', 'CH', 'CSWAP',
       'CRx', 'CRy', 'CRz', 'CU1', 'CU3',
-      'CV', 'CVdg', 'CSx', 'CSXdg'].includes(command.op.type)) {
+      'CV', 'CVdg', 'CSX', 'CSXdg', 'CS', 'CSdg',].includes(command.op.type)) {
       args.push(command.args[0])
       cc = {
         op: {


### PR DESCRIPTION
Update circuit renderer gate info displays to include PauliCommutingSet and PauliPair boxes.
Also add in new gates to be introduced in pytket 1.22