### PR TITLE
v0.7.4 release (plus linting)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.7.4] 2024-04-19
 ### Changed:
 - ConjugationBox display: render as a nested circuit.
 - Add nested circuit names.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pytket-circuit-renderer",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pytket-circuit-renderer",
   "description": "A Vue 3 component for rendering pytket circuits.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": false,
   "author": {
     "name": "Tiffany Duneau",

--- a/src/components/circuitDisplay/gateInfoSubCircuit.vue
+++ b/src/components/circuitDisplay/gateInfoSubCircuit.vue
@@ -26,7 +26,7 @@ export default {
     subCircuit () {
       // If circuit type is specified, we must extract that particular circuit from a conjugation box.
       const isConjBox = this.circuitType && this.opType === 'ConjugationBox'
-      let op = isConjBox ? this.op.box[this.circuitType.toLowerCase()] : this.op
+      const op = isConjBox ? this.op.box[this.circuitType.toLowerCase()] : this.op
 
       if (isConjBox) {
         if (!op) return false
@@ -35,7 +35,7 @@ export default {
           circuit: {
             qubits: this.args ?? [],
             bits: [],
-            commands: [{op, args: this.args}]
+            commands: [{ op, args: this.args }]
           },
           type: this.circuitType
         }

--- a/src/components/circuitDisplay/genericGate.vue
+++ b/src/components/circuitDisplay/genericGate.vue
@@ -80,18 +80,18 @@ export default {
           qubits: this.command.args,
           bits: [],
           commands: [
-              {op: this.command.op.box.compute, args: this.command.args},
-              {op: { type: 'Barrier' }, args: this.command.args},
-              {op: this.command.op.box.action, args: this.command.args},
-              {op: { type: 'Barrier' }, args: this.command.args},
-              {
-                op: (
-                  this.command.op.box.uncompute
-                    ? this.command.op.box.uncompute
-                    : { type: 'compute†' }
-                ),
-                args: this.command.args
-              }
+            { op: this.command.op.box.compute, args: this.command.args },
+            { op: { type: 'Barrier' }, args: this.command.args },
+            { op: this.command.op.box.action, args: this.command.args },
+            { op: { type: 'Barrier' }, args: this.command.args },
+            {
+              op: (
+                this.command.op.box.uncompute
+                  ? this.command.op.box.uncompute
+                  : { type: 'compute†' }
+              ),
+              args: this.command.args
+            }
           ]
         }
       } else {

--- a/src/components/circuitDisplay/utils.js
+++ b/src/components/circuitDisplay/utils.js
@@ -174,8 +174,8 @@ const extractControlledCommand = function (controlCommand, argDetails) {
       const controlState = command.op.box?.control_state ?? command.op.conditional?.value
       let bitstring = typeof controlState !== 'undefined' ? controlState.toString(2).padStart(args.length, '0') : false
       // Reverse if value was little-endian.
-      if (command.op.type == 'Conditional' && bitstring) {
-        bitstring = bitstring.split("").reverse().join("")
+      if (command.op.type === 'Conditional' && bitstring) {
+        bitstring = bitstring.split('').reverse().join('')
       }
       args.forEach((arg, i) => {
         if (arg in details) details[arg].control = true


### PR DESCRIPTION
bugfix release:

### Changed:
- ConjugationBox display: render as a nested circuit.
- Add nested circuit names.

### Fixed:
- DiagonalBox gateinfo label corrected.
- Little-endian classical controls
