### PR TITLE
Bugfix/tex

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.10.4] 2024-11-06
+### Fixed
+- Math display in circuit names now loads Tex settings properly (2): defer and isolate mathjax rendering to only the relevant components.
+
 ## [0.10.3] 2024-11-05
 ### Fixed
 - Math display in circuit names now loads Tex settings properly

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ You should then be able to run storybook to manually inspect the components via 
 Automated tests via cypress can be run using `npm run test`.
 
 ### Build
-To compile the component library use `npm run build-lib`.
+To compile the component library use `npm run parser` then `npm run build-lib`.
 Opening `test\index.html` gives an example app that uses the locally built circuit renderer.
 Note that you must be serving the local files, for example by first running `serve .` in the project root directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pytket-circuit-renderer",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pytket-circuit-renderer",
   "description": "A Vue 3 component for rendering pytket circuits.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": false,
   "author": {
     "name": "Tiffany Duneau",

--- a/src/components/mathjaxContent/mathjaxContent.vue
+++ b/src/components/mathjaxContent/mathjaxContent.vue
@@ -64,11 +64,9 @@ export default {
     renderMathJax () {
       if (this.isRenderingMath) {
         this.renderContent()
-        // If mathjax isn't loaded yet, wait for it to load
+        // Only typeset if mathjax has been loaded.
         if (!!window.MathJax && !!window.MathJax.typeset) {
-          this.$nextTick(() => {
-            window.MathJax.typeset(['[data-uid=' + this.uid + ']'])
-          })
+          window.MathJax.typeset(['[data-uid=' + this.uid + ']'])
         }
       }
     }

--- a/src/components/mathjaxContent/mathjaxContent.vue
+++ b/src/components/mathjaxContent/mathjaxContent.vue
@@ -1,7 +1,7 @@
 <script>
 // Vue wrapper for Mathjax.
 // Must use this if the formula can change dynamically.
-import './mathjaxLoader'
+import { loadMathjax } from './mathjaxLoader'
 import { renderOptions } from '@/components/circuitDisplay/provideKeys'
 
 let nMJC = 0
@@ -21,16 +21,24 @@ export default {
   data () {
     nMJC++
     return {
-      uid: 'mathjax-content-' + nMJC
+      uid: 'mathjax-content-' + nMJC,
+      ready: false
     }
   },
   watch: {
+    ready () {
+      this.renderMathJax()
+    },
     shouldReRender () {
       this.renderMathJax()
     },
     formula () {
       this.renderMathJax()
     }
+  },
+  async created () {
+    await loadMathjax()
+    this.ready = true
   },
   mounted () {
     this.renderMathJax()
@@ -56,6 +64,7 @@ export default {
     renderMathJax () {
       if (this.isRenderingMath) {
         this.renderContent()
+        // If mathjax isn't loaded yet, wait for it to load
         if (!!window.MathJax && !!window.MathJax.typeset) {
           this.$nextTick(() => {
             window.MathJax.typeset(['[data-uid=' + this.uid + ']'])

--- a/src/components/mathjaxContent/mathjaxLoader.js
+++ b/src/components/mathjaxContent/mathjaxLoader.js
@@ -1,22 +1,38 @@
 // load and configure mathjax
 
-(function () {
-  if (!window.MathJax) {
-    window.MathJax = {
-      loader: {
-        load: ['input/asciimath', 'input/tex']
-      },
-      tex: {
-        inlineMath: [['\\(', '\\)']],
-        displayMath: [['$$', '$$'], ['\\[', '\\]']]
-      },
-      asciimath: {
-        delimiters: [['`', '`']]
+export async function loadMathjax () {
+  if (!window.isLoadingMathjaxPromise) {
+    window.isLoadingMathjaxPromise = new Promise((resolve) => {
+      window.MathJax = {
+        loader: {
+          load: ['input/asciimath', 'input/tex']
+        },
+        tex: {
+          inlineMath: [['\\(', '\\)']],
+          displayMath: [['$$', '$$'], ['\\[', '\\]']]
+        },
+        asciimath: {
+          delimiters: [['`', '`']]
+        },
+        startup: {
+          async ready () {
+            window.MathJax.startup.defaultReady()
+            await window.MathJax.startup.promise
+            resolve(true)
+          },
+          pageReady () {
+            // Don't typeset entire page on initial load. Instead we return a dummy promise that resolves immediately.
+            // (Instead we expect any maths to be handled by the mathjax-content component)
+            return async () => true
+          }
+        }
       }
-    }
-    const script = document.createElement('script')
-    script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js'
-    script.async = true
-    document.head.appendChild(script)
+      const script = document.createElement('script')
+      script.id = 'mathjax-load-script'
+      script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js'
+      script.async = true
+      document.head.appendChild(script)
+    })
   }
-})()
+  return await window.isLoadingMathjaxPromise
+}

--- a/test/test_mjx_rendering.html
+++ b/test/test_mjx_rendering.html
@@ -1,0 +1,75 @@
+
+
+
+
+
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <!-- Download Vue 3-->
+<script type="application/javascript" src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+<!-- Download Circuit Renderer with styles -->
+
+<script type="application/javascript" src="/dist/pytket-circuit-renderer.umd.js"></script>
+<link rel="stylesheet" href="/dist/pytket-circuit-renderer.css">
+</head>
+<body>
+
+
+<div style="
+    position:absolute;
+    top:0;bottom:0;left:0;right:0;
+    margin:auto;resize:both;display:block;overflow:hidden;
+    width:min(500px, 100%);
+    height:min(None,100%);
+    max-width:100%;
+    max-height:100%;">
+
+    <div id="circuit-display-vue-container-47b85fc7-9220-4786-8ecc-45a201ed3f83" class="pytket-circuit-display-container">
+        <div style="display: none">
+            <div id="circuit-json-to-display">{"bits": [], "commands": [{"args": [["q", [0]], ["q", [1]], ["q", [2]]], "op": {"box": {"circuit": {"bits": [], "commands": [{"args": [["q", [0]], ["q", [2]]], "op": {"type": "SWAP"}}, {"args": [["q", [2]]], "op": {"type": "H"}}, {"args": [["q", [2]], ["q", [1]]], "op": {"params": ["-0.5"], "type": "CU1"}}, {"args": [["q", [2]], ["q", [0]]], "op": {"params": ["-0.25"], "type": "CU1"}}, {"args": [["q", [1]]], "op": {"type": "H"}}, {"args": [["q", [1]], ["q", [0]]], "op": {"params": ["-0.5"], "type": "CU1"}}, {"args": [["q", [0]]], "op": {"type": "H"}}], "created_qubits": [], "discarded_qubits": [], "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]], [["q", [2]], ["q", [2]]]], "name": "$$QFT^2$$", "phase": "0.0", "qubits": [["q", [0]], ["q", [1]], ["q", [2]]]}, "id": "db1677b0-7bbc-47bb-a0d9-6b0451182cbb", "type": "CircBox"}, "type": "CircBox"}}], "created_qubits": [], "discarded_qubits": [], "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]], [["q", [2]], ["q", [2]]]], "phase": "0.0", "qubits": [["q", [0]], ["q", [1]], ["q", [2]]]}</div>
+        </div>
+        <circuit-display-container
+                :circuit-element-str="'#circuit-json-to-display'"
+                :init-render-options="initRenderOptions"
+                view-format="None"
+        ></circuit-display-container>
+    </div>
+    <script type="application/javascript">
+      const circuitRendererUid = "47b85fc7-9220-4786-8ecc-45a201ed3f83";
+      const displayOptions = JSON.parse('{"zxStyle": true}');
+
+      // Script to initialise the circuit renderer app
+
+const { createApp } = Vue;
+const circuitDisplayContainer = window["pytket-circuit-renderer"].default;
+// Init variables to be shared between circuit display instances
+if (typeof window.pytketCircuitDisplays === "undefined") {
+    window.pytketCircuitDisplays = {};
+}
+// Create the root Vue component
+const app = createApp({
+    delimiters: ['[[#', '#]]'],
+    components: { circuitDisplayContainer },
+    data () {
+      return {
+        initRenderOptions: displayOptions,
+      }
+    }
+})
+app.config.unwrapInjectedRef = true;
+app.mount("#circuit-display-vue-container-"+circuitRendererUid);
+window.pytketCircuitDisplays[circuitRendererUid] = app;
+    </script>
+
+
+</div>
+
+
+</body>
+</html>
+
+


### PR DESCRIPTION
actual fix for https://github.com/CQCL/pytket-circuit-renderer/issues/76#issue-2636109964

Tex rendering is now deferred and fully controlled by `mathjax-content` component to avoid leakage.
This can be demoed by first building the code and serving it locally:
```
npm run parser
npm run build-lib
serve .
```

Then navigate to `http://localhost:3000/test/test_mjx_rendering`. It should look like this:
<img width="289" alt="Screenshot 2024-11-06 at 16 12 34" src="https://github.com/user-attachments/assets/0b233519-6470-4b6d-9c8e-3301338890db">

(This replicates the initial html generated by pytket)

Note that this issue won't be noticeable in storybook as mathjax is usually loaded before the circuit data as it is all done dynamically.